### PR TITLE
Add issuance metrics

### DIFF
--- a/src/context/metrics.ts
+++ b/src/context/metrics.ts
@@ -17,6 +17,8 @@ export class MetricsRegistry {
 	erroredRequestsTotal: CounterType;
 	keyRotationTotal: CounterType;
 	keyClearTotal: CounterType;
+	issuanceRequestTotal: CounterType;
+	signedTokenTotal: CounterType;
 
 	constructor(options: RegistryOptions) {
 		this.options = options;
@@ -37,6 +39,16 @@ export class MetricsRegistry {
 			'counter',
 			'key_clear_total',
 			'Number of key clear performed.'
+		);
+		this.issuanceRequestTotal = this.registry.create(
+			'counter',
+			'issuance_request_total',
+			'Number of requests for private token issuance.'
+		);
+		this.signedTokenTotal = this.registry.create(
+			'counter',
+			'signed_token_total',
+			'Number of issued signed private tokens.'
 		);
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ interface StorageMetadata extends Record<string, string> {
 }
 
 export const handleTokenRequest = async (ctx: Context, request: Request) => {
+	ctx.metrics.issuanceRequestTotal.inc({ env: ctx.env.ENVIRONMENT });
 	const contentType = request.headers.get('content-type');
 	if (!contentType || contentType !== MediaType.PRIVATE_TOKEN_REQUEST) {
 		throw new HeaderNotDefinedError(`"Content-Type" must be "${MediaType.PRIVATE_TOKEN_REQUEST}"`);
@@ -71,6 +72,7 @@ export const handleTokenRequest = async (ctx: Context, request: Request) => {
 	const domain = new URL(request.url).host;
 	const issuer = new Issuer(domain, sk, pk);
 	const signedToken = await issuer.issue(tokenRequest);
+	ctx.metrics.signedTokenTotal.inc({ env: ctx.env.ENVIRONMENT });
 
 	return new Response(signedToken.serialize(), {
 		headers: { 'content-type': MediaType.PRIVATE_TOKEN_RESPONSE },


### PR DESCRIPTION
Add specific metrics for issuance: number of requests to the issuance endpoints (/token-request), number of signed tokens.

This allows for a better monitoring of the issuer activity.