### PR TITLE
Add support for RSABSSA signing when built in the engine

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ export default {
 				'^@/(.*)$': '<rootDir>/src/$1',
 				'^(\\.{1,2}/.*)\\.js$': '$1',
 			},
+			setupFilesAfterEnv: ['./test/jest.setup-file.ts'],
 			// it was harder than expected to setup
 			// more documentation on https://miniflare.dev/testing/jest
 			testEnvironment: 'miniflare',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "pp-issuer",
 			"version": "0.1.0",
 			"dependencies": {
-				"@cloudflare/privacypass-ts": "0.4.0",
+				"@cloudflare/privacypass-ts": "0.5.1",
 				"@sentry/cli": "2.26.0",
 				"@sentry/types": "7.95.0",
 				"promjs": "0.4.2",
@@ -16,7 +16,7 @@
 				"typescript": "5.3.3"
 			},
 			"devDependencies": {
-				"@cloudflare/blindrsa-ts": "0.2.0",
+				"@cloudflare/blindrsa-ts": "0.3.2",
 				"@cloudflare/workers-types": "4.20240117.0",
 				"@types/jest": "29.5.11",
 				"dotenv": "16.4.0",
@@ -721,10 +721,9 @@
 			"dev": true
 		},
 		"node_modules/@cloudflare/blindrsa-ts": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/blindrsa-ts/-/blindrsa-ts-0.2.0.tgz",
-			"integrity": "sha512-rc0tamvqNl9Fq9AHHb5KGPi+maLl/e6oI106r5GOY67Q/6S0t2lUW3sDaOTPOHfev2zQa9QrzZBrDzE7bMn8KA==",
-			"dev": true,
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@cloudflare/blindrsa-ts/-/blindrsa-ts-0.3.2.tgz",
+			"integrity": "sha512-JWV+LH2ZB1RSZsinesVFK5rrStPevw3/lMmNdhbKlQsTXQXqCXUFxwuYlFwyDxVzQyl/rdB/vUIgxc7PXit/TQ==",
 			"dependencies": {
 				"sjcl": "1.0.8"
 			},
@@ -742,11 +741,12 @@
 			}
 		},
 		"node_modules/@cloudflare/privacypass-ts": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/privacypass-ts/-/privacypass-ts-0.4.0.tgz",
-			"integrity": "sha512-z4a6yxQb5fy8hpPBcScPe/InxppQY7omxzYXT8YIXpYDU0LU15N6I30isKMmaJ5zyLXU3liwPN6vEInxdA2oTg==",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/privacypass-ts/-/privacypass-ts-0.5.1.tgz",
+			"integrity": "sha512-YVYmn2C3NlmZ6xQhirlLBZb4Ds13c6L2WMseK73+PpAiiXoGKtHYidvhyg1IVjCAPVPHUPD6SYBm3PftPh0NqA==",
 			"dependencies": {
-				"@cloudflare/blindrsa-ts": "0.1.0",
+				"@cloudflare/blindrsa-ts": "0.3.2",
+				"@cloudflare/voprf-ts": "0.21.2",
 				"asn1-parser": "1.1.8",
 				"asn1js": "3.0.5",
 				"rfc4648": "1.5.2"
@@ -755,15 +755,16 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/@cloudflare/privacypass-ts/node_modules/@cloudflare/blindrsa-ts": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/blindrsa-ts/-/blindrsa-ts-0.1.0.tgz",
-			"integrity": "sha512-Tl1EPjVip5STWKMpEuRNiMB868UC2cg5qwzUEkM7w+isuwVWd3GQ55JrjFuGgwQXV0lTSaN5b46ASdBqBmvCGQ==",
-			"dependencies": {
-				"sjcl": "1.0.8"
-			},
+		"node_modules/@cloudflare/voprf-ts": {
+			"version": "0.21.2",
+			"resolved": "https://registry.npmjs.org/@cloudflare/voprf-ts/-/voprf-ts-0.21.2.tgz",
+			"integrity": "sha512-S61I3QMSovLbfhm+kOx6Zgj7q9PHS+XJvVecJeQ0UNza3dvw/bgaZ/1Y5vHhbucMUSKiw3HoCph/lV7uZCApeA==",
 			"engines": {
 				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@noble/curves": "1.2.0",
+				"@noble/hashes": "1.3.2"
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
@@ -2027,6 +2028,30 @@
 			},
 			"engines": {
 				"node": ">=16.13"
+			}
+		},
+		"node_modules/@noble/curves": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+			"integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+			"optional": true,
+			"dependencies": {
+				"@noble/hashes": "1.3.2"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@noble/hashes": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+			"integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+			"optional": true,
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		]
 	},
 	"devDependencies": {
-		"@cloudflare/blindrsa-ts": "0.2.0",
+		"@cloudflare/blindrsa-ts": "0.3.2",
 		"@cloudflare/workers-types": "4.20240117.0",
 		"@types/jest": "29.5.11",
 		"dotenv": "16.4.0",
@@ -38,7 +38,7 @@
 		"wrangler": "3.24.0"
 	},
 	"dependencies": {
-		"@cloudflare/privacypass-ts": "0.4.0",
+		"@cloudflare/privacypass-ts": "0.5.1",
 		"@sentry/cli": "2.26.0",
 		"@sentry/types": "7.95.0",
 		"promjs": "0.4.2",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -21,6 +21,19 @@ declare global {
 		| 'deriveBits'
 		| 'wrapKey'
 		| 'unwrapKey';
+
+	// privacypass requires these interface to be in scope
+	interface Algorithm {
+		name: string;
+	}
+
+	type AlgorithmIdentifier = Algorithm | string;
+
+	type HashAlgorithmIdentifier = AlgorithmIdentifier;
+
+	interface RsaHashedImportParams extends Algorithm {
+		hash: HashAlgorithmIdentifier;
+	}
 }
 
 export {};

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,9 +7,10 @@ import { RSABSSA } from '@cloudflare/blindrsa-ts';
 import {
 	MediaType,
 	PRIVATE_TOKEN_ISSUER_DIRECTORY,
-	TokenRequest,
+	publicVerif,
 	util,
 } from '@cloudflare/privacypass-ts';
+const { TokenRequest } = publicVerif;
 
 const sampleURL = 'http://localhost';
 

--- a/test/jest.setup-file.ts
+++ b/test/jest.setup-file.ts
@@ -1,0 +1,42 @@
+import { RSABSSA } from '@cloudflare/blindrsa-ts';
+
+interface RsaPssParams extends Algorithm {
+	saltLength: number;
+}
+
+interface EcdsaParams extends Algorithm {
+	hash: HashAlgorithmIdentifier;
+}
+
+const parentSign = crypto.subtle.sign;
+
+// RSA-RAW is not supported by WebCrypto, but is available in Workers
+// Taken from cloudflare/blindrsa-ts https://github.com/cloudflare/blindrsa-ts/blob/b7a4c669620fba62ce736fe84445635e222d0d11/test/jest.setup-file.ts#L8-L32
+async function mockSign(
+	algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams,
+	key: CryptoKey,
+	data: Uint8Array
+): Promise<ArrayBuffer> {
+	if (algorithm === 'RSA-RAW' || (typeof algorithm !== 'string' && algorithm?.name === 'RSA-RAW')) {
+		const algorithmName = key.algorithm.name;
+		if (algorithmName !== 'RSA-RAW') {
+			throw new Error(`Invalid key algorithm: ${algorithmName}`);
+		}
+		key.algorithm.name = 'RSA-PSS';
+		try {
+			// await is needed here because if the promised is returned, the algorithmName could be restored before the key is used, causing an error
+			return await RSABSSA.SHA384.PSSZero.Deterministic().blindSign(key, data);
+		} finally {
+			key.algorithm.name = algorithmName;
+		}
+	}
+
+	console.log('somehow mock', algorithm);
+	// webcrypto calls crypto, which is mocked. We need to restore the original implementation.
+	crypto.subtle.sign = parentSign;
+	const res = crypto.subtle.sign(algorithm, key, data);
+	crypto.subtle.sign = mockSign;
+	return res;
+}
+
+crypto.subtle.sign = mockSign;


### PR DESCRIPTION
Cloudflare Workers supports native blind signature when CryptoKey algorithm is marked as [`RSA-RAW`](https://github.com/cloudflare/workerd/blob/3c85053b83a5200dffc5be5ae26cbe7577cd5ea5/src/workerd/api/crypto.c%2B%2B#L122). Using the engine for blind signature instead of relying on JavaScript libraries provides significant performance improvement.

This commit adds an optional variable `EXPERIMENTAL_RSABSSA`, which when set to `'true'` enables engine signing.
Given this is specific to Cloudflare Workers, this feature is not deemed relevant to upstream to @cloudflare/privacypass-ts or @cloudflare/blindrsa-ts, which aim to be more general. In addition, miniflare does not provide a way to test this feature, therefore the experimental flagging.