### PR TITLE
Add cache issuer directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
 				"@cloudflare/blindrsa-ts": "0.3.2",
 				"@cloudflare/workers-types": "4.20240117.0",
 				"@types/jest": "29.5.11",
+				"@typescript-eslint/eslint-plugin": "^6.21.0",
+				"@typescript-eslint/parser": "^6.21.0",
 				"dotenv": "16.4.0",
 				"esbuild": "0.19.12",
 				"eslint": "8.56.0",
@@ -2412,11 +2414,10 @@
 			}
 		},
 		"node_modules/@types/json-schema": {
-			"version": "7.0.11",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
-			"dev": true,
-			"peer": true
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+			"dev": true
 		},
 		"node_modules/@types/node": {
 			"version": "18.15.12",
@@ -2439,11 +2440,10 @@
 			"peer": true
 		},
 		"node_modules/@types/semver": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
-			"dev": true,
-			"peer": true
+			"version": "7.5.7",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.7.tgz",
+			"integrity": "sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg==",
+			"dev": true
 		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.1",
@@ -2467,33 +2467,33 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.59.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.5.tgz",
-			"integrity": "sha512-feA9xbVRWJZor+AnLNAr7A8JRWeZqHUf4T9tlP+TN04b05pFVhO5eN7/O93Y/1OUlLMHKbnJisgDURs/qvtqdg==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
+			"integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
-				"@eslint-community/regexpp": "^4.4.0",
-				"@typescript-eslint/scope-manager": "5.59.5",
-				"@typescript-eslint/type-utils": "5.59.5",
-				"@typescript-eslint/utils": "5.59.5",
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "6.21.0",
+				"@typescript-eslint/type-utils": "6.21.0",
+				"@typescript-eslint/utils": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
 				"debug": "^4.3.4",
-				"grapheme-splitter": "^1.0.4",
-				"ignore": "^5.2.0",
-				"natural-compare-lite": "^1.4.0",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^5.0.0",
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -2502,26 +2502,26 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.59.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.5.tgz",
-			"integrity": "sha512-NJXQC4MRnF9N9yWqQE2/KLRSOLvrrlZb48NGVfBa+RuPMN6B7ZcK5jZOvhuygv4D64fRKnZI4L4p8+M+rfeQuw==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+			"integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.59.5",
-				"@typescript-eslint/types": "5.59.5",
-				"@typescript-eslint/typescript-estree": "5.59.5",
+				"@typescript-eslint/scope-manager": "6.21.0",
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/typescript-estree": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -2530,17 +2530,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.59.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.5.tgz",
-			"integrity": "sha512-jVecWwnkX6ZgutF+DovbBJirZcAxgxC0EOHYt/niMROf8p4PwxxG32Qdhj/iIQQIuOflLjNkxoXyArkcIP7C3A==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+			"integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.59.5",
-				"@typescript-eslint/visitor-keys": "5.59.5"
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2548,26 +2547,25 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.59.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.5.tgz",
-			"integrity": "sha512-4eyhS7oGym67/pSxA2mmNq7X164oqDYNnZCUayBwJZIRVvKpBCMBzFnFxjeoDeShjtO6RQBHBuwybuX3POnDqg==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
+			"integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "5.59.5",
-				"@typescript-eslint/utils": "5.59.5",
+				"@typescript-eslint/typescript-estree": "6.21.0",
+				"@typescript-eslint/utils": "6.21.0",
 				"debug": "^4.3.4",
-				"tsutils": "^3.21.0"
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "*"
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -2576,13 +2574,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.59.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.5.tgz",
-			"integrity": "sha512-xkfRPHbqSH4Ggx4eHRIO/eGL8XL4Ysb4woL8c87YuAo8Md7AUjyWKa9YMwTL519SyDPrfEgKdewjkxNCVeJW7w==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+			"integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
 			"dev": true,
-			"peer": true,
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2590,22 +2587,22 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.59.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.5.tgz",
-			"integrity": "sha512-+XXdLN2CZLZcD/mO7mQtJMvCkzRfmODbeSKuMY/yXbGkzvA9rJyDY5qDYNoiz2kP/dmyAxXquL2BvLQLJFPQIg==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+			"integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.59.5",
-				"@typescript-eslint/visitor-keys": "5.59.5",
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"semver": "^7.3.7",
-				"tsutils": "^3.21.0"
+				"minimatch": "9.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2617,45 +2614,66 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/utils": {
-			"version": "5.59.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.5.tgz",
-			"integrity": "sha512-sCEHOiw+RbyTii9c3/qN74hYDPNORb8yWCoPLmB7BIflhplJ65u2PBpdRla12e3SSTJ2erRkPjz7ngLHhUegxA==",
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.2.0",
-				"@types/json-schema": "^7.0.9",
-				"@types/semver": "^7.3.12",
-				"@typescript-eslint/scope-manager": "5.59.5",
-				"@typescript-eslint/types": "5.59.5",
-				"@typescript-eslint/typescript-estree": "5.59.5",
-				"eslint-scope": "^5.1.1",
-				"semver": "^7.3.7"
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@typescript-eslint/utils": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+			"integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "6.21.0",
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/typescript-estree": "6.21.0",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"eslint": "^7.0.0 || ^8.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.59.5",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.5.tgz",
-			"integrity": "sha512-qL+Oz+dbeBRTeyJTIy0eniD3uvqU7x+y1QceBismZ41hd4aBSRh8UAw4pZP0+XzLuPZmx4raNMq/I+59W2lXKA==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+			"integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.59.5",
-				"eslint-visitor-keys": "^3.3.0"
+				"@typescript-eslint/types": "6.21.0",
+				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2791,7 +2809,6 @@
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3359,7 +3376,6 @@
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
 			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"path-type": "^4.0.0"
 			},
@@ -3577,20 +3593,6 @@
 				"typescript": "*"
 			}
 		},
-		"node_modules/eslint-scope": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
 		"node_modules/eslint-visitor-keys": {
 			"version": "3.4.3",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
@@ -3803,16 +3805,6 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
 		"node_modules/estree-walker": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
@@ -3895,11 +3887,10 @@
 			"dev": true
 		},
 		"node_modules/fast-glob": {
-			"version": "3.2.12",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
@@ -4153,7 +4144,6 @@
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
 			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
@@ -4174,13 +4164,6 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true
-		},
-		"node_modules/grapheme-splitter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
@@ -6065,7 +6048,6 @@
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 8"
 			}
@@ -6188,13 +6170,6 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
-		},
-		"node_modules/natural-compare-lite": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/node-fetch": {
 			"version": "2.6.11",
@@ -7289,6 +7264,18 @@
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
 		},
+		"node_modules/ts-api-utils": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
+			"integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.2.0"
+			}
+		},
 		"node_modules/ts-jest": {
 			"version": "29.1.2",
 			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.2.tgz",
@@ -7330,29 +7317,6 @@
 				"esbuild": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/tsutils": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"tslib": "^1.8.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			},
-			"peerDependencies": {
-				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
 			}
 		},
 		"node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -15,14 +15,28 @@
 	"eslintConfig": {
 		"root": true,
 		"extends": [
-			"typescript",
+			"plugin:@typescript-eslint/recommended",
 			"prettier"
-		]
+		],
+		"parser": "@typescript-eslint/parser",
+		"plugins": [
+			"@typescript-eslint"
+		],
+		"rules": {
+			"@typescript-eslint/no-unused-vars": [
+				"warn",
+				{
+					"argsIgnorePattern": "^_"
+				}
+			]
+		}
 	},
 	"devDependencies": {
 		"@cloudflare/blindrsa-ts": "0.3.2",
 		"@cloudflare/workers-types": "4.20240117.0",
 		"@types/jest": "29.5.11",
+		"@typescript-eslint/eslint-plugin": "^6.21.0",
+		"@typescript-eslint/parser": "^6.21.0",
 		"dotenv": "16.4.0",
 		"esbuild": "0.19.12",
 		"eslint": "8.56.0",

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -2,6 +2,7 @@ import type { R2Bucket } from '@cloudflare/workers-types/2023-07-01';
 
 export interface Bindings {
 	// variables and secrets
+	DIRECTORY_CACHE_MAX_AGE_SECONDS: string;
 	ENVIRONMENT: string;
 	LOGGING_SHIM_TOKEN: string;
 	SENTRY_ACCESS_CLIENT_ID: string;

--- a/src/context/metrics.ts
+++ b/src/context/metrics.ts
@@ -13,23 +13,32 @@ export class MetricsRegistry {
 	registry: RegistryType;
 	options: RegistryOptions;
 
-	requestsTotal: CounterType;
+	directoryCacheMissTotal: CounterType;
 	erroredRequestsTotal: CounterType;
+	issuanceRequestTotal: CounterType;
 	keyRotationTotal: CounterType;
 	keyClearTotal: CounterType;
-	issuanceRequestTotal: CounterType;
+	requestsTotal: CounterType;
 	signedTokenTotal: CounterType;
-	directoryCacheMissTotal: CounterType;
 
 	constructor(options: RegistryOptions) {
 		this.options = options;
 		this.registry = new Registry();
 
-		this.requestsTotal = this.registry.create('counter', 'requests_total', 'total requests');
+		this.directoryCacheMissTotal = this.registry.create(
+			'counter',
+			'directory_cache_miss_total',
+			'Number of requests for private token issuer directory which are not served by the cache.'
+		);
 		this.erroredRequestsTotal = this.registry.create(
 			'counter',
 			'errored_requests_total',
 			'Errored requests served to eyeball'
+		);
+		this.issuanceRequestTotal = this.registry.create(
+			'counter',
+			'issuance_request_total',
+			'Number of requests for private token issuance.'
 		);
 		this.keyRotationTotal = this.registry.create(
 			'counter',
@@ -41,20 +50,11 @@ export class MetricsRegistry {
 			'key_clear_total',
 			'Number of key clear performed.'
 		);
-		this.issuanceRequestTotal = this.registry.create(
-			'counter',
-			'issuance_request_total',
-			'Number of requests for private token issuance.'
-		);
+		this.requestsTotal = this.registry.create('counter', 'requests_total', 'total requests');
 		this.signedTokenTotal = this.registry.create(
 			'counter',
 			'signed_token_total',
 			'Number of issued signed private tokens.'
-		);
-		this.directoryCacheMissTotal = this.registry.create(
-			'counter',
-			'directory_cache_miss_total',
-			'Number of requests for private token issuer directory which are not served by the cache.'
 		);
 	}
 

--- a/src/context/metrics.ts
+++ b/src/context/metrics.ts
@@ -19,6 +19,7 @@ export class MetricsRegistry {
 	keyClearTotal: CounterType;
 	issuanceRequestTotal: CounterType;
 	signedTokenTotal: CounterType;
+	directoryCacheMissTotal: CounterType;
 
 	constructor(options: RegistryOptions) {
 		this.options = options;
@@ -49,6 +50,11 @@ export class MetricsRegistry {
 			'counter',
 			'signed_token_total',
 			'Number of issued signed private tokens.'
+		);
+		this.directoryCacheMissTotal = this.registry.create(
+			'counter',
+			'directory_cache_miss_total',
+			'Number of requests for private token issuer directory which are not served by the cache.'
 		);
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ const DIRECTORY_CACHE_REQUEST = new Request(
 	`https://${FAKE_DOMAIN_CACHE}${PRIVATE_TOKEN_ISSUER_DIRECTORY}`
 );
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const handleTokenDirectory = async (ctx: Context, request?: Request) => {
 	const cache = await getDirectoryCache();
 	const cachedResponse = await cache.match(DIRECTORY_CACHE_REQUEST);
@@ -126,6 +127,7 @@ const clearDirectoryCache = async (): Promise<boolean> => {
 	return cache.delete(DIRECTORY_CACHE_REQUEST);
 };
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const handleRotateKey = async (ctx: Context, request?: Request) => {
 	ctx.metrics.keyRotationTotal.inc({ env: ctx.env.ENVIRONMENT });
 
@@ -176,6 +178,7 @@ export const handleRotateKey = async (ctx: Context, request?: Request) => {
 	return new Response(`New key ${publicKeyEnc}`, { status: 201 });
 };
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const handleClearKey = async (ctx: Context, request?: Request) => {
 	ctx.metrics.keyClearTotal.inc({ env: ctx.env.ENVIRONMENT });
 	const keys = await ctx.env.ISSUANCE_KEYS.list();

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,7 @@ export const handleTokenDirectory = async (ctx: Context, request?: Request) => {
 	if (cachedResponse) {
 		return cachedResponse;
 	}
+	ctx.metrics.directoryCacheMissTotal.inc({ env: ctx.env.ENVIRONMENT });
 
 	const keys = await ctx.env.ISSUANCE_KEYS.list({ include: ['customMetadata'] });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,6 @@ export const handleHeadTokenDirectory = async (ctx: Context, request: Request) =
 	});
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const handleTokenDirectory = async (ctx: Context, request: Request) => {
 	const cache = await getDirectoryCache();
 	const cachedResponse = await cache.match(DIRECTORY_CACHE_REQUEST);
@@ -153,8 +152,7 @@ const clearDirectoryCache = async (): Promise<boolean> => {
 	return cache.delete(DIRECTORY_CACHE_REQUEST);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const handleRotateKey = async (ctx: Context, request?: Request) => {
+export const handleRotateKey = async (ctx: Context, _request?: Request) => {
 	ctx.metrics.keyRotationTotal.inc({ env: ctx.env.ENVIRONMENT });
 
 	// Generate a new type 2 Issuer key
@@ -204,8 +202,7 @@ export const handleRotateKey = async (ctx: Context, request?: Request) => {
 	return new Response(`New key ${publicKeyEnc}`, { status: 201 });
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const handleClearKey = async (ctx: Context, request?: Request) => {
+const handleClearKey = async (ctx: Context, _request?: Request) => {
 	ctx.metrics.keyClearTotal.inc({ env: ctx.env.ENVIRONMENT });
 	const keys = await ctx.env.ISSUANCE_KEYS.list();
 
@@ -236,7 +233,6 @@ export default {
 		const router = new Router();
 
 		router
-			.head(PRIVATE_TOKEN_ISSUER_DIRECTORY, handleHeadTokenDirectory)
 			.get(PRIVATE_TOKEN_ISSUER_DIRECTORY, handleTokenDirectory)
 			.post('/token-request', handleTokenRequest)
 			.post('/admin/rotate', handleRotateKey)

--- a/src/router.ts
+++ b/src/router.ts
@@ -44,6 +44,19 @@ export class Router {
 		// normalise path, so that they never end with a trailing '/'
 		path = this.normalisePath(path);
 		this.handlers[method][path] = handler;
+		if (method === HttpMethod.GET) {
+			this.handlers[HttpMethod.HEAD] ??= {};
+			this.handlers[HttpMethod.HEAD][path] = async (
+				ctx: Context,
+				request: Request
+			): Promise<Response> => {
+				const response = await handler(ctx, request);
+				if (response.ok) {
+					return new Response(null, response);
+				}
+				return response;
+			};
+		}
 		return this;
 	}
 

--- a/src/utils/hex.ts
+++ b/src/utils/hex.ts
@@ -1,0 +1,12 @@
+export const hexDecode = (s: string) => {
+	const bytes = s.match(/.{1,2}/g);
+	if (!bytes) {
+		return new Uint8Array(0);
+	}
+	return Uint8Array.from(bytes.map(b => parseInt(b, 16)));
+};
+
+export const hexEncode = (u: Uint8Array) =>
+	Array.from(u)
+		.map(b => b.toString(16).padStart(2, '0'))
+		.join('');

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -3,6 +3,31 @@ import { Context, WaitUntilFunc } from '../src/context';
 import { ConsoleLogger, Logger } from '../src/context/logging';
 import { MetricsRegistry } from '../src/context/metrics';
 
+export class MockCache implements Cache {
+	public cache: Record<string, Response> = {};
+
+	async match(info: RequestInfo, options?: CacheQueryOptions): Promise<Response | undefined> {
+		if (options) {
+			throw new Error('CacheQueryOptions not supported');
+		}
+		const url = new URL(info instanceof Request ? info.url : info).href;
+		return this.cache[url];
+	}
+
+	async delete(info: RequestInfo, options?: CacheQueryOptions): Promise<boolean> {
+		if (options) {
+			throw new Error('CacheQueryOptions not supported');
+		}
+		const url = new URL(info instanceof Request ? info.url : info).href;
+		return delete this.cache[url];
+	}
+
+	async put(info: RequestInfo, response: Response): Promise<void> {
+		const url = new URL(info instanceof Request ? info.url : info).href;
+		this.cache[url] = response;
+	}
+}
+
 export class ExecutionContextMock implements ExecutionContext {
 	waitUntils: Promise<any>[] = [];
 	passThrough = false;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,6 +14,7 @@ route = { pattern = "pp-issuer.example.test", custom_domain=true }
 crons = ["0 0 * * *"]
 
 [env.production.vars]
+DIRECTORY_CACHE_MAX_AGE_SECONDS = "86400"
 ENVIRONMENT = "production"
 SENTRY_SAMPLE_RATE = "0" # Between 0-1 if you log errors on Sentry. 0 disables Sentry logging. Configuration is done through Workers Secrets
 


### PR DESCRIPTION
To reduce the number of calls to R2, with an expensive list operation, add cache in front of issuer directory endpoint.

It's worth noting that this change does not affect token issuance. The key is still retrieve for every issuance, incurring a class A operation.