### PR TITLE
Rename pp-issuer to privacypass-issuer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pp-issuer
+# privacypass-issuer
 
 Privacy Pass Issuer ([Draft 16](https://www.ietf.org/archive/id/draft-ietf-privacypass-protocol-16.html)) within Cloudflare Workers. Keys are stored in [R2](https://developers.cloudflare.com/r2).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "pp-issuer",
+	"name": "privacypass-issuer",
 	"version": "0.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "pp-issuer",
+			"name": "privacypass-issuer",
 			"version": "0.1.0",
 			"dependencies": {
 				"@cloudflare/privacypass-ts": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "pp-issuer",
+	"name": "privacypass-issuer",
 	"version": "0.1.0",
 	"type": "module",
 	"main": "dist/worker.mjs",


### PR DESCRIPTION
Repositories are going to be renamed. This updates the configuration for deployment